### PR TITLE
Use project specific eslint

### DIFF
--- a/lint.js
+++ b/lint.js
@@ -1,3 +1,4 @@
+const resolveFrom = require('resolve-from');
 const URI = require('vscode-uri').default;
 const lsp = require('vscode-languageserver');
 const eslint = require('eslint');
@@ -12,9 +13,15 @@ const SEVERITY_MAP = {
     2: lsp.DiagnosticSeverity.Error,
 };
 
+function getLinter() {
+  const eslintModulePath = resolveFrom(root, 'eslint');
+  const eslint = require(eslintModulePath); // eslint-disable-line
+  return new eslint.CLIEngine({ cwd: root });
+}
+
 function lintDocument(event) {
     const document = event.document;
-    const linter = new eslint.CLIEngine({cwd: root});
+    const linter = getLinter();
     const report = linter.executeOnText(document.getText(), URI.parse(document.uri).fsPath);
     const messages = report.results[0] ? report.results[0].messages : [];
     const diagnostics = messages.map(message => ({

--- a/lint.js
+++ b/lint.js
@@ -5,9 +5,6 @@ const eslint = require('eslint');
 
 const {connection, documents, root} = require('./index');
 
-// try to load the eslintrc
-new eslint.CLIEngine({cwd: root});
-
 const SEVERITY_MAP = {
     1: lsp.DiagnosticSeverity.Warning,
     2: lsp.DiagnosticSeverity.Error,


### PR DESCRIPTION
The linter is failing with the following error if a project uses some locally installed eslint plugins:

> Failed to load plugin react: Cannot find module 'eslint-plugin-react'

This PR changes the server to load 'eslint' from the project's directory and not the server's one -- making any locally installed plugin visible to the instantiated linter.