### PR TITLE
New tern version + support for`defs` and `loadEagerly`

### DIFF
--- a/analysis.js
+++ b/analysis.js
@@ -1,26 +1,14 @@
-const {Server: TernServer} = require('tern');
-const fs = require('fs');
+const bootstrapServer = require('tern/lib/bootstrap');
 const path = require('path');
 const util = require('util');
 const URI = require('vscode-uri').default;
-const ternProject = require('./tern-project');
 
 const {connection, documents, root} = require('./index');
 
-const tern = new TernServer(Object.assign(ternProject(root), {
-    getFile(file, cb) {
-        fs.readFile(path.resolve(root, file), 'utf8', cb);
-    },
-    normalizeFilename(name) {
-        name = path.resolve(root, name);
-        try {
-            name = fs.realpathSync(name);
-        } catch (e) {} // eslint-disable-line no-empty
-        return path.relative(root, name);
-    },
-    async: true,
-}));
-// TODO loadEagerly
+const tern = bootstrapServer({
+  projectDir: root,
+  debug: true,
+});
 tern.asyncRequest = util.promisify(tern.request);
 async function ternRequest(event, type, options = {}) {
     return await tern.asyncRequest({

--- a/analysis.js
+++ b/analysis.js
@@ -7,7 +7,6 @@ const {connection, documents, root} = require('./index');
 
 const tern = bootstrapServer({
   projectDir: root,
-  debug: true,
 });
 tern.asyncRequest = util.promisify(tern.request);
 async function ternRequest(event, type, options = {}) {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "eslint": "^4.19.1",
     "resolve-from": "^4.0.0",
-    "tern": "^0.21.0",
+    "tern": "^0.24.3",
     "vscode-languageserver": "^4.1.2"
   }
 }

--- a/tern-project.js
+++ b/tern-project.js
@@ -27,7 +27,7 @@ module.exports = function(root) {
         if (fs.existsSync(file)) return file;
         file = path.resolve(ternRoot, kind, filename);
         if (fs.existsSync(file)) return file;
-        file = resolveFrom(`tern-${name}`, root);
+        file = resolveFrom(root, `tern-${name}`);
         if (fs.existsSync(file)) return file;
         file = require.resolve(`tern-${name}`);
         if (fs.existsSync(file)) return file;

--- a/tern-project.js
+++ b/tern-project.js
@@ -46,11 +46,22 @@ module.exports = function(root) {
             mod.initialize(ternRoot);
     });
 
-    // TODO load defs
+    // load defs
+    const defs = (project.libs || []).reduce((acc, lib) => {
+        const file = find('defs', lib, '.json');
+        if (file === undefined) {
+            // eslint-disable-next-line no-console
+            console.error(`Failed to load tern lib ${lib}`);
+            return;
+        }
+        acc.push(file);
+        return acc;
+    }, []);
 
     return {
         projectDir: root,
         plugins: project.plugins,
+        defs,
         ecmaVersion: project.ecmaVersion || 6,
         dependencyBudget: project.dependencyBudget,
     };

--- a/tern-project.js
+++ b/tern-project.js
@@ -47,16 +47,16 @@ module.exports = function(root) {
     });
 
     // load defs
-    const defs = (project.libs || []).reduce((acc, lib) => {
+    const defs = [];
+    for (const lib of (project.libs || [])) {
         const file = find('defs', lib, '.json');
         if (file === undefined) {
             // eslint-disable-next-line no-console
             console.error(`Failed to load tern lib ${lib}`);
-            return;
+            continue;
         }
-        acc.push(file);
-        return acc;
-    }, []);
+        defs.push(file);
+    }
 
     return {
         projectDir: root,

--- a/tern-project.js
+++ b/tern-project.js
@@ -61,6 +61,7 @@ module.exports = function(root) {
     return {
         projectDir: root,
         plugins: project.plugins,
+        loadEagerly: project.loadEagerly,
         defs,
         ecmaVersion: project.ecmaVersion || 6,
         dependencyBudget: project.dependencyBudget,


### PR DESCRIPTION
## Update tern.js

The newer version of tern.js ships with a new interface for starting
a server programmatically (https://github.com/ternjs/tern/pull/1000),
and by using that we can simplify the integration a bit.

## Fix the order of arguments of `resolveFrom` call


## Add support for loading tern custom definitions


## Propagate the `loadEagerly` flag

